### PR TITLE
Expose close

### DIFF
--- a/bp/_bp.pxd
+++ b/bp/_bp.pxd
@@ -43,7 +43,7 @@ cdef class BP:
     cdef SIZE_t excess(self, SIZE_t i) nogil
     cdef SIZE_t fwdsearch(self, SIZE_t i, int d) nogil
     cdef SIZE_t bwdsearch(self, SIZE_t i, int d) nogil
-    cdef inline SIZE_t close(self, SIZE_t i) nogil
+    cpdef inline SIZE_t close(self, SIZE_t i) nogil
     cdef inline SIZE_t open(self, SIZE_t i) nogil
     cpdef inline BOOL_t isleaf(self, SIZE_t i) nogil
     cdef inline SIZE_t enclose(self, SIZE_t i) nogil

--- a/bp/_bp.pyx
+++ b/bp/_bp.pyx
@@ -327,7 +327,7 @@ cdef class BP:
         # same as: self.rank(1, i) - self.rank(0, i)
         return self._e_index[i]
     
-    cdef inline SIZE_t close(self, SIZE_t i) nogil:
+    cpdef inline SIZE_t close(self, SIZE_t i) nogil:
         """The position of the closing parenthesis that matches B[i]"""
         if not self._b_ptr[i]:
             # identity: the close of a closed parenthesis is itself

--- a/bp/tests/test_bp.py
+++ b/bp/tests/test_bp.py
@@ -197,6 +197,11 @@ class BPTests(TestCase):
         for i, e in enumerate(exp):
             self.assertEqual(self.BP.levelnext(i), e)
 
+    def test_close(self):
+        exp = [21, 10, 3, 5, 9, 8, 12, 20, 19, 16, 18]
+        for i, e in zip(np.argwhere(self.BP.B == 1).squeeze(), exp):
+            npt.assert_equal(self.BP.close(i), e)
+
     def test_lca(self):
         # lca(i, j) = parent(rmq(i, j) + 1)
         # unless isancestor(i, j)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ classes = """
     Topic :: Scientific/Engineering
     Programming Language :: Python
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Operating System :: Unix
     Operating System :: POSIX
     Operating System :: MacOS :: MacOS X
@@ -73,7 +74,7 @@ class BitArrayInstall(build_py):
 
 
 setup(name='iow',
-      version="0.1.2",
+      version="0.1.3",
       description='Balanced parentheses',
       author='Daniel McDonald',
       author_email='mcdonadt@colorado.edu',


### PR DESCRIPTION
@kwcantrell, could you review when you have a moment? I had a need for `close()` to be available from Python. If good, we can cut a release after (perhaps after reviewing additional issues?) 